### PR TITLE
Reader: identify more archive members as BSD symbol tables

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -202,8 +202,8 @@ func (rd *Reader) Next() (*Header, error) {
 			return nil, err
 		}
 	case BSD:
-		// The special file name "__.SYMDEF" indicates that the data section contains a symbol table.
-		if header.Name == "__.SYMDEF" {
+		// The special file name "__.SYMDEF" (and variations of it) indicates that the data section contains a symbol table.
+		if header.Name == "__.SYMDEF" || header.Name == "__.SYMDEF SORTED" || header.Name == "__.SYMDEF_64" {
 			// The symbol table should be invisible to the caller - skip over it.
 			return rd.Next()
 		}


### PR DESCRIPTION
`__.SYMDEF SORTED` and `__.SYMDEF_64` are both known to be written by ranlib on Darwin. Don't consider them to be actual files for the purpose of reading archives.