### PR TITLE
Reader: add Variant function

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -143,6 +143,11 @@ func (rd *Reader) skipUnread() error {
 	return err
 }
 
+// Variant returns the ar file format variant used by the archive file.
+func (rd *Reader) Variant() Variant {
+	return rd.variant
+}
+
 // Next skips to the next file in the archive file.
 // Returns a Header which contains the metadata about the
 // file in the archive. io.EOF is returned at the end of the input.

--- a/reader_test.go
+++ b/reader_test.go
@@ -55,10 +55,11 @@ func TestReadHeader(t *testing.T) {
 func TestLongFilenames(t *testing.T) {
 	for _, tc := range []struct {
 		Description string
+		Variant     Variant
 		ArchivePath string
 	}{
-		{"BSD format", "./test_data/long_filenames_bsd.a"},
-		{"GNU format", "./test_data/long_filenames_gnu.a"},
+		{"BSD format", BSD, "./test_data/long_filenames_bsd.a"},
+		{"GNU format", GNU, "./test_data/long_filenames_gnu.a"},
 	} {
 		t.Run(tc.Description, func(t *testing.T) {
 			f, err := os.Open(tc.ArchivePath)
@@ -66,6 +67,7 @@ func TestLongFilenames(t *testing.T) {
 			defer f.Close()
 			reader, err := NewReader(f)
 			require.NoError(t, err)
+			assert.Equal(t, tc.Variant, reader.Variant())
 			for i := 1; i <= 20; i++ {
 				t.Run("File "+strconv.Itoa(i), func(t *testing.T) {
 					hdr, err := reader.Next()


### PR DESCRIPTION
This allows the caller to discover which ar file format variant was automatically detected by `NewReader`.