### PR TITLE
Writer: append trailing slash to <= 15-byte GNU file names

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -216,7 +216,7 @@ func (aw *Writer) WriteHeader(hdr *Header) error {
 			}
 			aw.string(s.next(16), "/"+strconv.Itoa(offset))
 		} else {
-			aw.string(s.next(16), hdr.Name)
+			aw.string(s.next(16), hdr.Name+"/")
 		}
 	case BSD:
 		// In the BSD variant of the ar format, file names that won't fit in the file name header are

--- a/writer.go
+++ b/writer.go
@@ -216,7 +216,11 @@ func (aw *Writer) WriteHeader(hdr *Header) error {
 			}
 			aw.string(s.next(16), "/"+strconv.Itoa(offset))
 		} else {
-			aw.string(s.next(16), hdr.Name+"/")
+			// File names beginning with "/" aren't real file names - don't append "/" to them.
+			if hdr.Name[0] != '/' {
+				hdr.Name = hdr.Name + "/"
+			}
+			aw.string(s.next(16), hdr.Name)
 		}
 	case BSD:
 		// In the BSD variant of the ar format, file names that won't fit in the file name header are


### PR DESCRIPTION
The GNU variant of the ar format expects all file names to have trailing slashes, regardless of whether they are stored in the string table or in the file name header field.