### PR TITLE
Writer: ensure file name is not empty

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -196,6 +196,10 @@ func (aw *Writer) WriteHeader(hdr *Header) error {
 	header := make([]byte, HEADER_BYTE_SIZE)
 	s := slicer(header)
 
+	if len(hdr.Name) == 0 {
+		return errors.New("ar: empty file name")
+	}
+
 	switch aw.variant {
 	case GNU:
 		// "/" is always appended to GNU-variant file names, which means that any file names over 15 bytes

--- a/writer_test.go
+++ b/writer_test.go
@@ -26,6 +26,7 @@ func TestWriteTooLong(t *testing.T) {
 	body := "Hello world!\n"
 
 	hdr := new(Header)
+	hdr.Name = "hello.txt"
 	hdr.Size = 1
 
 	var buf bytes.Buffer


### PR DESCRIPTION
The value of `Name` in `Header` is the file's real name, and it makes no sense for it to be undefined. Ensure it has a non-zero length before writing the header to the archive.