### PR TITLE
Report external ar tool output on `TestWriteValidArchive` failure

### DIFF
--- a/writer_test.go
+++ b/writer_test.go
@@ -122,9 +122,10 @@ func TestWriteValidArchive(t *testing.T) {
 			err = f.Close()
 			require.NoError(t, err)
 
-			cmd := exec.Command(tc.ArPath, append(tc.ArArgs, "-x", tmp)...)
-			err = cmd.Run()
-			require.NoError(t, err)
+			out, err = exec.Command(tc.ArPath, append(tc.ArArgs, "-x", tmp)...).CombinedOutput()
+			if !assert.NoError(t, err) {
+				t.Fatalf("%s output:\n%s\n", tc.ArPath, out)
+			}
 
 			for i, fileName := range fileNames {
 				fi, err := os.Stat(fileName)


### PR DESCRIPTION
It's not very helpful seeing

```
Failure:  in TestWriteValidArchive/GNU_ar
writer_test.go:126:
        	Error Trace:
        	Error:      	Received unexpected error:
        	            	exit status 1
        	Test:       	TestWriteValidArchive/GNU_ar
```

when one of the `TestWriteValidArchive` subtests fails. Additionally report what the tool printed on stderr and stdout to make the nature of the failure more obvious.