### PR TITLE
Reader: fill the buffer passed to `Read`

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -283,7 +283,7 @@ func (rd *Reader) Read(b []byte) (n int, err error) {
 	if int64(len(b)) > rd.nb {
 		b = b[0:rd.nb]
 	}
-	n, err = rd.r.Read(b)
+	n, err = io.ReadFull(rd.r, b)
 	rd.nb -= int64(n)
 
 	return


### PR DESCRIPTION
`bufio.Reader.Read(p)` may read fewer than `len(p)` bytes from the underlying `io.Reader` into `p`. When it does, archive members appear artificially truncated; when this happens to the string table, it leads to red herring errors (e.g. missing entries, missing trailing newlines).

After capping `len(p)` to the remaining number of bytes to be read from the current member's data section, ensure that exactly `len(p)` bytes are read from the underlying `io.Reader` when reading the string table.