### PR TITLE
Writer: don't prepend file mode bits to file mode field

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -81,7 +81,7 @@ func (aw *Writer) numeric(b []byte, x int64) {
 }
 
 func (aw *Writer) octal(b []byte, x int64) {
-	s := "100" + strconv.FormatInt(x, 8)
+	s := strconv.FormatInt(x, 8)
 	for len(s) < len(b) {
 		s = s + " "
 	}


### PR DESCRIPTION
ar archives are only capable of storing regular files, so the file mode bits that `Reader` prepends to every file mode header field are redundant (and it forces users to strip them off manually whenever a file header passes through a `Writer` multiple times, otherwise they accumulate and overflow the header field). Just encode the mode we were given - which may or may not contain file mode bits of its own, at the caller's discretion - in octal and insert it into the header field.