### PR TITLE
Reader: resolve BSD-variant file names before checking for symbol tables

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -186,13 +186,13 @@ func (rd *Reader) Next() (*Header, error) {
 			return nil, err
 		}
 	case BSD:
+		if err := rd.parseBSDFileName(header); err != nil {
+			return nil, err
+		}
 		// The special file name "__.SYMDEF" (and variations of it) indicates that the data section contains a symbol table.
 		if header.Name == "__.SYMDEF" || header.Name == "__.SYMDEF SORTED" || header.Name == "__.SYMDEF_64" {
 			// The symbol table should be invisible to the caller - skip over it.
 			return rd.Next()
-		}
-		if err := rd.parseBSDFileName(header); err != nil {
-			return nil, err
 		}
 	}
 


### PR DESCRIPTION
Darwin's `ar(1)` writes BSD-variant archives and treats file names containing exactly 16 characters as long file names; this causes it to write sorted symbol tables with the file name `#1/16`, which only becomes `__.SYMDEF SORTED` after long file names have been resolved. Parse the file name before checking whether it is indicative of the archive member being a symbol table.

Fixes #22.